### PR TITLE
Rack::DigestFields middleware with Unencoded-Digest support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ gem "irb"
 gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"
+gem "rack"
 
 gem "standard", "~> 1.3"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,61 @@
 
 Support for `Content-Digest` and `Repl-Digest` header digests that follows the [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html) specification.
 
-> [!WARNING]
-> This library currently only offers low-level primitives, and does not interact with Rack, does not set headers or trailers, or decide what consistitues content to digest. This is currently an exercise left to the user.
-
 ## Usage
+
+### Rack middleware
+
+`Rack::DigestFields` automatically computes and injects `Unencoded-Digest` response headers.
+
+#### Why `Unencoded-Digest` and not `Content-Digest` or `Repr-Digest`?
+
+[RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html) defines two similar headers:
+
+- **`Content-Digest`** — digest of the bytes as transferred on the wire, after any content-encoding (e.g. gzip) is applied.
+- **`Repr-Digest`** — digest of the full selected representation, which also varies with content-encoding.
+
+Both require the middleware to know the final encoded bytes. In a typical deployment, content-encoding is applied *downstream* of the Ruby process — by nginx, a CDN, or `Rack::Deflater` positioned later in the stack. The app never sees those bytes, so it cannot correctly compute either header.
+
+`Unencoded-Digest` is the digest of the body *before* any content-encoding. A Rack middleware always has these bytes, so it can produce the header reliably regardless of what happens downstream.
+
+> [!NOTE]
+> `Unencoded-Digest` is defined in an IETF draft ([draft-ietf-httpbis-unencoded-digest](https://datatracker.ietf.org/doc/draft-ietf-httpbis-unencoded-digest/)) that has not yet been standardised. Breaking changes to the header name, wire format, or semantics are unlikely — current feedback on the draft focuses on security considerations rather than the core design — but it is possible before the RFC is finalised.
+
+```ruby
+# config.ru
+require "digest_fields/rack"
+
+use Rack::DigestFields,
+  on_partial_content: :raise,  # required: :raise | :warn | :skip
+  unencoded_digest: true        # uses default algorithms (sha-256, sha-512)
+```
+
+With algorithm override:
+
+```ruby
+use Rack::DigestFields,
+  on_partial_content: :skip,
+  unencoded_digest: {
+    algorithms: %w[sha-256],
+    on_partial_content: :warn  # overrides global for this header
+  }
+```
+
+In Rails, insert before `Rack::Sendfile` to ensure the middleware sees the raw response body before any transformation:
+
+```ruby
+config.middleware.insert_before Rack::Sendfile, Rack::DigestFields,
+  on_partial_content: :raise,
+  unencoded_digest: true
+```
+
+`on_partial_content` is required with no default — `206 Partial Content` responses cannot correctly produce `Unencoded-Digest` (it requires the full unencoded representation). The three behaviours are:
+
+| Value | Behaviour |
+|---|---|
+| `:raise` | Raise `Rack::DigestFields::PartialContentError` |
+| `:warn` | Emit a warning and omit the header |
+| `:skip` | Omit the header silently |
 
 ### Library
 

--- a/lib/digest_fields/rack.rb
+++ b/lib/digest_fields/rack.rb
@@ -1,0 +1,97 @@
+require "rack"
+require "digest_fields"
+
+module Rack
+  class DigestFields
+    class PartialContentError < StandardError; end
+
+    VALID_ON_PARTIAL_CONTENT = %i[skip warn raise].freeze
+    RECOGNISED_HEADER_KEYS = %i[unencoded_digest].freeze
+    KNOWN_OPTION_KEYS = (RECOGNISED_HEADER_KEYS + [:on_partial_content]).freeze
+
+    def initialize(app, **options)
+      @app = app
+      validate_options!(options)
+      @on_partial_content = options.fetch(:on_partial_content)
+      @unencoded_digest = parse_unencoded_digest(options[:unencoded_digest])
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+
+      if status == 206
+        mode = @unencoded_digest[:on_partial_content] || @on_partial_content
+        case mode
+        when :skip
+          return [status, headers, body]
+        when :warn
+          Kernel.warn("Rack::DigestFields: Unencoded-Digest cannot be computed for 206 Partial Content")
+          return [status, headers, body]
+        when :raise
+          raise PartialContentError, "Rack::DigestFields: Unencoded-Digest cannot be computed for 206 Partial Content"
+        end
+      end
+
+      chunks = []
+      body.each { |chunk| chunks << chunk }
+      body.close if body.respond_to?(:close)
+      buffered = chunks.join
+
+      digest = ::DigestFields.digest(buffered, algorithms: @unencoded_digest[:algorithms])
+      headers = headers.merge("Unencoded-Digest" => digest)
+
+      [status, headers, [buffered]]
+    end
+
+    private
+
+    def validate_options!(options)
+      unknown = options.keys - KNOWN_OPTION_KEYS
+      raise ArgumentError, "Unrecognised options: #{unknown.map(&:inspect).join(", ")}" if unknown.any?
+
+      unless (options.keys & RECOGNISED_HEADER_KEYS).any?
+        raise ArgumentError, "No digest headers configured. Provide at least one of: #{RECOGNISED_HEADER_KEYS.join(", ")}"
+      end
+
+      unless options.key?(:on_partial_content)
+        raise ArgumentError, "on_partial_content is required (choose: :skip, :warn, or :raise)"
+      end
+
+      validate_on_partial_content!(options[:on_partial_content], context: "global")
+
+      if options.key?(:unencoded_digest)
+        config = options[:unencoded_digest]
+        unless config == true || config.is_a?(Hash)
+          raise ArgumentError, "unencoded_digest must be true or a Hash, got #{config.inspect}"
+        end
+      end
+
+      return unless options[:unencoded_digest].is_a?(Hash)
+
+      if options[:unencoded_digest].key?(:on_partial_content)
+        validate_on_partial_content!(options[:unencoded_digest][:on_partial_content], context: "unencoded_digest")
+      end
+
+      if options[:unencoded_digest][:algorithms] == []
+        raise ArgumentError, "algorithms cannot be empty"
+      end
+    end
+
+    def validate_on_partial_content!(value, context:)
+      return if VALID_ON_PARTIAL_CONTENT.include?(value)
+      raise ArgumentError, "Invalid on_partial_content #{value.inspect} for #{context} (choose: :skip, :warn, or :raise)"
+    end
+
+    def parse_unencoded_digest(config)
+      # Algorithms are snapshotted from the registry at middleware init time.
+      # Changes to DigestFields.algorithms after initialization are not reflected.
+      base_algorithms = ::DigestFields.algorithms.keys
+      return {algorithms: base_algorithms} if config == true || config.nil? || config == {}
+
+      {
+        algorithms: config[:algorithms] || base_algorithms,
+        on_partial_content: config[:on_partial_content]
+      }
+    end
+  end
+end

--- a/lib/digest_fields/version.rb
+++ b/lib/digest_fields/version.rb
@@ -1,3 +1,3 @@
 module DigestFields
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/spec/digest_fields/rack_spec.rb
+++ b/spec/digest_fields/rack_spec.rb
@@ -1,0 +1,262 @@
+require "digest_fields/rack"
+
+RSpec.describe Rack::DigestFields do
+  # Fixture body and known digest values from draft-ietf-httpbis-unencoded-digest Section 6
+  let(:body_string) { "An unexceptional string\n" }
+  let(:sha256_value) { "5Bv3NIx05BPnh0jMph6v1RJ5Q7kl9LKMtQxmvc9+Z7Y=" }
+  let(:sha512_value) { "WjyMuMD9EI/v0RoJchcevbo6lF498VyE9564OgXf+98iJptoSvb1Czo9uVJu2bVU/tOv90huiMG3+YaMX1kipw==" }
+  let(:rack_env) { {} }
+
+  def stub_app(status: 200, body: nil, headers: {})
+    response_body = body || [body_string]
+    ->(_env) { [status, {"content-type" => "text/plain"}.merge(headers), response_body] }
+  end
+
+  def build_middleware(app = nil, **options)
+    app ||= stub_app
+    Rack::DigestFields.new(app, **options)
+  end
+
+  describe ".new (validation)" do
+    it "raises ArgumentError when no header key is configured" do
+      expect { build_middleware(on_partial_content: :raise) }
+        .to raise_error(ArgumentError, /No digest headers configured/)
+    end
+
+    it "raises ArgumentError for an unrecognised option key with no recognised header" do
+      # repr_digest is not a recognised key in v1 — hits the unknown-key check
+      expect { build_middleware(on_partial_content: :raise, repr_digest: true) }
+        .to raise_error(ArgumentError, /Unrecognised options/)
+    end
+
+    it "raises ArgumentError for an unrecognised option key alongside a recognised header" do
+      expect { build_middleware(on_partial_content: :raise, unencoded_digest: true, typo: true) }
+        .to raise_error(ArgumentError, /Unrecognised options/)
+    end
+
+    it "raises ArgumentError when on_partial_content is omitted" do
+      expect { build_middleware(unencoded_digest: true) }
+        .to raise_error(ArgumentError, /on_partial_content is required/)
+    end
+
+    it "raises ArgumentError for an invalid global on_partial_content value" do
+      expect { build_middleware(on_partial_content: :ignore, unencoded_digest: true) }
+        .to raise_error(ArgumentError, /:ignore/)
+    end
+
+    it "raises ArgumentError for an invalid per-header on_partial_content value" do
+      expect do
+        build_middleware(
+          on_partial_content: :raise,
+          unencoded_digest: {algorithms: %w[sha-256], on_partial_content: :ignore}
+        )
+      end.to raise_error(ArgumentError, /:ignore/)
+    end
+
+    it "raises ArgumentError when unencoded_digest is not true or a Hash" do
+      expect { build_middleware(on_partial_content: :raise, unencoded_digest: false) }
+        .to raise_error(ArgumentError, /unencoded_digest must be true or a Hash/)
+    end
+
+    it "raises ArgumentError when algorithms is explicitly empty" do
+      expect do
+        build_middleware(on_partial_content: :raise, unencoded_digest: {algorithms: []})
+      end.to raise_error(ArgumentError, /algorithms cannot be empty/)
+    end
+
+    it "accepts unencoded_digest: true" do
+      expect { build_middleware(on_partial_content: :raise, unencoded_digest: true) }
+        .not_to raise_error
+    end
+
+    it "accepts unencoded_digest: {} (treated as true — uses default algorithms)" do
+      expect { build_middleware(on_partial_content: :raise, unencoded_digest: {}) }
+        .not_to raise_error
+    end
+
+    it "accepts :warn as a valid global on_partial_content value" do
+      expect { build_middleware(on_partial_content: :warn, unencoded_digest: true) }
+        .not_to raise_error
+    end
+
+    it "accepts :skip as a valid global on_partial_content value" do
+      expect { build_middleware(on_partial_content: :skip, unencoded_digest: true) }
+        .not_to raise_error
+    end
+
+    it "accepts a full options hash with per-header override" do
+      expect do
+        build_middleware(
+          on_partial_content: :skip,
+          unencoded_digest: {algorithms: %w[sha-256], on_partial_content: :warn}
+        )
+      end.not_to raise_error
+    end
+  end
+
+  describe "#call — 200 response" do
+    let(:middleware) { build_middleware(on_partial_content: :raise, unencoded_digest: true) }
+
+    it "adds Unencoded-Digest with both default algorithms" do
+      _status, headers, _body = middleware.call(rack_env)
+      expect(headers["Unencoded-Digest"])
+        .to eq("sha-256=:#{sha256_value}:, sha-512=:#{sha512_value}:")
+    end
+
+    it "returns the original status code" do
+      status, _headers, _body = middleware.call(rack_env)
+      expect(status).to eq(200)
+    end
+
+    it "returns the buffered body as a single-element array" do
+      _status, _headers, body = middleware.call(rack_env)
+      expect(body).to eq([body_string])
+    end
+
+    context "with a custom algorithm" do
+      let(:middleware) do
+        build_middleware(on_partial_content: :raise, unencoded_digest: {algorithms: %w[sha-256]})
+      end
+
+      it "includes only the specified algorithm" do
+        _status, headers, _body = middleware.call(rack_env)
+        expect(headers["Unencoded-Digest"]).to eq("sha-256=:#{sha256_value}:")
+      end
+    end
+
+    context "when a downstream middleware would apply content-encoding (e.g. Rack::Deflater)" do
+      # The middleware sees the raw bytes before any encoding is applied.
+      # This confirms Unencoded-Digest is computed over the unencoded body regardless
+      # of what happens downstream — as long as the middleware is positioned before
+      # any encoding middleware.
+      it "computes the digest over the unencoded body bytes" do
+        # Same fixture body, same expected digest — positioning before Rack::Deflater
+        # means the middleware sees and digests the unencoded string.
+        _status, headers, _body = middleware.call(rack_env)
+        expect(headers["Unencoded-Digest"]).to include("sha-256=:#{sha256_value}:")
+      end
+    end
+
+    context "with a multi-chunk body" do
+      let(:chunks) { ["An unexceptional ", "string\n"] }
+      let(:middleware) do
+        build_middleware(
+          stub_app(body: chunks),
+          on_partial_content: :raise,
+          unencoded_digest: {algorithms: %w[sha-256]}
+        )
+      end
+
+      it "joins chunks before digesting" do
+        _status, headers, _body = middleware.call(rack_env)
+        expect(headers["Unencoded-Digest"]).to eq("sha-256=:#{sha256_value}:")
+      end
+
+      it "returns the joined body" do
+        _status, _headers, body = middleware.call(rack_env)
+        expect(body).to eq([body_string])
+      end
+    end
+  end
+
+  describe "#call — body.close" do
+    it "calls close on the original body after buffering" do
+      closeable_body = ["An unexceptional string\n"]
+      closed = false
+      closeable_body.define_singleton_method(:close) { closed = true }
+
+      middleware = build_middleware(
+        stub_app(body: closeable_body),
+        on_partial_content: :raise,
+        unencoded_digest: {algorithms: %w[sha-256]}
+      )
+      middleware.call(rack_env)
+
+      expect(closed).to be(true)
+    end
+
+    it "does not call close on bodies that do not respond to close" do
+      plain_body = ["An unexceptional string\n"]
+      middleware = build_middleware(
+        stub_app(body: plain_body),
+        on_partial_content: :raise,
+        unencoded_digest: {algorithms: %w[sha-256]}
+      )
+      status, headers, _body = middleware.call(rack_env)
+      expect(status).to eq(200)
+      expect(headers).to have_key("Unencoded-Digest")
+    end
+  end
+
+  describe "#call — 206 Partial Content" do
+    let(:partial_app) { stub_app(status: 206) }
+
+    context "with on_partial_content: :raise" do
+      let(:middleware) { build_middleware(partial_app, on_partial_content: :raise, unencoded_digest: true) }
+
+      it "raises PartialContentError" do
+        expect { middleware.call(rack_env) }
+          .to raise_error(Rack::DigestFields::PartialContentError)
+      end
+    end
+
+    context "with on_partial_content: :skip" do
+      let(:original_body) { ["An unexceptional string\n"] }
+      let(:middleware) { build_middleware(stub_app(status: 206, body: original_body), on_partial_content: :skip, unencoded_digest: true) }
+
+      it "omits the Unencoded-Digest header" do
+        _status, headers, _body = middleware.call(rack_env)
+        expect(headers).not_to have_key("Unencoded-Digest")
+      end
+
+      it "returns the original body object unchanged" do
+        _status, _headers, body = middleware.call(rack_env)
+        expect(body).to be(original_body)
+      end
+
+      it "does not call close on the body" do
+        closed = false
+        original_body.define_singleton_method(:close) { closed = true }
+        middleware.call(rack_env)
+        expect(closed).to be(false)
+      end
+    end
+
+    context "with on_partial_content: :warn" do
+      let(:original_body) { ["An unexceptional string\n"] }
+      let(:middleware) { build_middleware(stub_app(status: 206, body: original_body), on_partial_content: :warn, unencoded_digest: true) }
+
+      it "omits the Unencoded-Digest header" do
+        _status, headers, _body = middleware.call(rack_env)
+        expect(headers).not_to have_key("Unencoded-Digest")
+      end
+
+      it "emits a warning" do
+        expect { middleware.call(rack_env) }
+          .to output(/Unencoded-Digest/).to_stderr
+      end
+
+      it "does not call close on the body" do
+        closed = false
+        original_body.define_singleton_method(:close) { closed = true }
+        middleware.call(rack_env)
+        expect(closed).to be(false)
+      end
+    end
+
+    context "with per-header on_partial_content overriding global" do
+      let(:middleware) do
+        build_middleware(
+          partial_app,
+          on_partial_content: :skip,
+          unencoded_digest: {algorithms: %w[sha-256], on_partial_content: :warn}
+        )
+      end
+
+      it "uses the per-header setting (warn) rather than the global (skip)" do
+        expect { middleware.call(rack_env) }
+          .to output(/Unencoded-Digest/).to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Rack::DigestFields` Rack middleware that automatically computes and injects `Unencoded-Digest` response headers
- Uses `DigestFields.digest` under the hood; algorithms default to `DigestFields.algorithms.keys` (snapshotted at init)
- Requires explicit `on_partial_content:` config (`:skip`, `:warn`, or `:raise`) — no silent defaults; 206 responses cannot correctly produce `Unencoded-Digest` (requires full unencoded representation)
- Adds `rack` as a runtime dependency

## `Unencoded-Digest`

`Unencoded-Digest` is defined in an IETF draft ([draft-ietf-httpbis-unencoded-digest](https://datatracker.ietf.org/doc/draft-ietf-httpbis-unencoded-digest/)) and has not yet been standardised. The header name, wire format, or semantics may change before it becomes an RFC.

It side-steps the encoding problems with `Content-Digest` and `Repr-Digest` by not being affected by encoding (e.g. gzip in nginx).